### PR TITLE
Remove sparse dataset dependency

### DIFF
--- a/Per_Site_Fish_Metric_Tibble.R
+++ b/Per_Site_Fish_Metric_Tibble.R
@@ -274,10 +274,11 @@ fish_table$BENTHIC_INSECTIVORE <- ifelse((fish_table$BENTHIC + fish_table$INVLVF
                                          0
                                          )
 
-# Create Tibble for Storing all Site Metrics. 
+# Create Tibble with basic diversity indices from 'vegan'.
+# This tibble will be the base for storing all additional computed site metrics. 
 site_metric_tibble <- create_site_metric_tibble(fish_table)
 
-# Compute and Add Additional Desired Metrics to the base table called site_metric_tibble
+# Compute and add additional site metrics to site_metric_tibble
 site_metric_tibble$CATONTAX <- num_taxa_by_trait(fish_table, Family, 'Catostomidae')
 site_metric_tibble$CATOPTAX <- round(site_metric_tibble$CATONTAX/site_metric_tibble$RICHNESS, digits = 3)
 site_metric_tibble$CATONIND <- num_ind_by_trait(fish_table, Family, 'Catostomidae')


### PR DESCRIPTION
Remove metric calculations that require the use of a sparse data set. Instead create a function that will take the tidy data set (like the output from a database) and  temporarily create a sparse data set for using the 'vegan' package to compute diversity and evenness indices. The script then requires only 1 input data table to be able to produce the per site metric list. It will remove potential redundancy in data. 